### PR TITLE
Update evpi_val function

### DIFF
--- a/R/voipred.R
+++ b/R/voipred.R
@@ -30,7 +30,7 @@ evpi_val <- function(Y, pi, method=c("bootstrap","bayesian_bootstrap","asymptoti
         
         
         tryCatch(
-          {ENB_perfect[j] <- do.call(mu_max_trunc_bvn,as.list(parms))}
+          {ENB_perfect[j] <- mu_max_trunc_bvn(parms[1],parms[2],parms[3],parms[4],parms[5])
           , error=function(cond) {
             return(NULL)
           })


### PR DESCRIPTION
do.call requires the function input names to be exactly the same which is too restrictive